### PR TITLE
Fix for Issue #26 - Handle unquoted symbols in cljs.edn

### DIFF
--- a/src/tool/core.cljs
+++ b/src/tool/core.cljs
@@ -197,7 +197,7 @@
         onload (str
                  "(do "
                  "  (def ^:dynamic *cljs-config* (quote " config "))"
-                 "  (def ^:dynamic *build-config* " build ")"
+                 "  (def ^:dynamic *build-config* (quote " build "))"
                  "  nil)")
         args (concat ["-cp" cp "clojure.main" "-e" onload script-path] args)]
     (spawn-sync java-path (clj->js args) #js{:stdio "inherit"})))


### PR DESCRIPTION
It turns out that we were passing the unquoted symbol names to the clojure process without quoting was causing them to be evaluated, and therefore throwing an exception. This change fixes that.

One interesting consequence of this change is that if you now attempt to use a quoted symbol in the cljs.edn config as map key, it causes an exception further down stack during the build task.